### PR TITLE
Adding SecretJWT authentication to Spring Security , also addresses i…

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
@@ -19,6 +19,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterNames;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterValues;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.util.Assert;
@@ -123,6 +125,11 @@ abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T extend
 		}
 		if (ClientAuthenticationMethod.POST.equals(clientRegistration.getClientAuthenticationMethod())) {
 			body.with(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
+		}
+		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+			body.with(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
+			body.with(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
+
 		}
 		Set<String> scopes = scopes(grantRequest);
 		if (!CollectionUtils.isEmpty(scopes)) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverter.java
@@ -24,6 +24,8 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterValues;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterNames;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -85,6 +87,10 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverter implements Conve
 		}
 		if (ClientAuthenticationMethod.POST.equals(clientRegistration.getClientAuthenticationMethod())) {
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
+		}
+		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
+			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 		}
 		if (codeVerifier != null) {
 			formParameters.add(PkceParameterNames.CODE_VERIFIER, codeVerifier);

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
@@ -50,7 +50,9 @@ abstract class StdConverters {
 			if (ClientAuthenticationMethod.BASIC.getValue().equalsIgnoreCase(value)) {
 				return ClientAuthenticationMethod.BASIC;
 			} else if (ClientAuthenticationMethod.POST.getValue().equalsIgnoreCase(value)) {
-				return ClientAuthenticationMethod.POST;
+				return ClientAuthenticationMethod.POST;}
+			else if (ClientAuthenticationMethod.SECRET_JWT.getValue().equalsIgnoreCase(value)) {
+				return ClientAuthenticationMethod.SECRET_JWT;
 			} else if (ClientAuthenticationMethod.NONE.getValue().equalsIgnoreCase(value)) {
 				return ClientAuthenticationMethod.NONE;
 			}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.client.registration;
 
+import com.nimbusds.jose.JWSAlgorithm;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,6 +31,7 @@ import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.oauth2.core.AuthenticationMethod;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -47,6 +49,7 @@ public final class ClientRegistration implements Serializable {
 	private String registrationId;
 	private String clientId;
 	private String clientSecret;
+	private String clientAssertionSigningAlgorithm = JwsAlgorithms.HS256;
 	private ClientAuthenticationMethod clientAuthenticationMethod = ClientAuthenticationMethod.BASIC;
 	private AuthorizationGrantType authorizationGrantType;
 	private String redirectUriTemplate;
@@ -139,6 +142,15 @@ public final class ClientRegistration implements Serializable {
 		return this.clientName;
 	}
 
+	/**
+	 * Returns the Signing Algorithm used for Client Assertion
+	 *
+	 * @return the {@link String}
+	 */
+	public String getClientAssertionSigningAlgorithm() {
+		return this.clientAssertionSigningAlgorithm;
+	}
+
 	@Override
 	public String toString() {
 		return "ClientRegistration{"
@@ -151,6 +163,7 @@ public final class ClientRegistration implements Serializable {
 			+ ", scopes=" + this.scopes
 			+ ", providerDetails=" + this.providerDetails
 			+ ", clientName='" + this.clientName
+			+ ", clientAssertionSigningAlgorithm='" + this.clientAssertionSigningAlgorithm
 			+ '\'' + '}';
 	}
 
@@ -311,6 +324,7 @@ public final class ClientRegistration implements Serializable {
 		private String issuerUri;
 		private Map<String, Object> configurationMetadata = Collections.emptyMap();
 		private String clientName;
+		private String clientAssertionSigningAlgorithm = JwsAlgorithms.HS256;
 
 		private Builder(String registrationId) {
 			this.registrationId = registrationId;
@@ -336,6 +350,7 @@ public final class ClientRegistration implements Serializable {
 				this.configurationMetadata = new HashMap<>(configurationMetadata);
 			}
 			this.clientName = clientRegistration.clientName;
+			this.clientAssertionSigningAlgorithm = clientRegistration.clientAssertionSigningAlgorithm;
 		}
 
 		/**
@@ -537,6 +552,16 @@ public final class ClientRegistration implements Serializable {
 			this.clientName = clientName;
 			return this;
 		}
+		/**
+		 * Sets the Client Assertion Signature Algorithm
+		 *
+		 * @param clientAssertionSigningAlgorithm the client or registration name
+		 * @return the {@link Builder}
+		 */
+		public Builder clientAssertionSigningAlgorithm(String clientAssertionSigningAlgorithm) {
+			this.clientAssertionSigningAlgorithm = clientAssertionSigningAlgorithm;
+			return this;
+		}
 
 		/**
 		 * Builds a new {@link ClientRegistration}.
@@ -588,6 +613,7 @@ public final class ClientRegistration implements Serializable {
 			clientRegistration.clientName = StringUtils.hasText(this.clientName) ?
 					this.clientName : this.registrationId;
 
+			clientRegistration.clientAssertionSigningAlgorithm = this.clientAssertionSigningAlgorithm;
 			return clientRegistration;
 		}
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
@@ -261,6 +261,9 @@ public final class ClientRegistrations {
 		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.CLIENT_SECRET_POST)) {
 			return ClientAuthenticationMethod.POST;
 		}
+		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.CLIENT_SECRET_JWT)) {
+			return ClientAuthenticationMethod.SECRET_JWT;
+		}
 		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.NONE)) {
 			return ClientAuthenticationMethod.NONE;
 		}

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
@@ -31,6 +31,7 @@ public final class ClientAuthenticationMethod implements Serializable {
 	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
 	public static final ClientAuthenticationMethod BASIC = new ClientAuthenticationMethod("basic");
 	public static final ClientAuthenticationMethod POST = new ClientAuthenticationMethod("post");
+	public static final ClientAuthenticationMethod SECRET_JWT = new ClientAuthenticationMethod("secret_jwt");
 
 	/**
 	 * @since 5.2

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterNames.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterNames.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *
+ *  * Copyright 2020 Paychex, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.security.oauth2.core.endpoint;
+
+/**
+ * @author visweshwarganesh
+ * @Created 06/20/2020 - 9:13 AM
+ * RFC-7521 Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants
+ * https://tools.ietf.org/html/rfc7521#section-9
+ */
+public interface ClientAssertionParameterNames {
+
+	/**
+	 * {@code assertion} - used in Access Token Request.
+	 */
+	String ASSERTION = "assertion";
+
+	/**
+	 * {@code client_assertion} - used in Access Token Request.
+	 */
+	String CLIENT_ASSERTION = "client_assertion";
+
+	/**
+	 * {@code client_assertion_type} - used in Access Token Request.
+	 */
+	String CLIENT_ASSERTION_TYPE = "client_assertion_type";
+}

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterValues.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterValues.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *
+ *  * Copyright 2020 Paychex, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.security.oauth2.core.endpoint;
+
+/**
+ * @author visweshwarganesh
+ * @Created 06/20/2020 - 9:21 AM
+ * RFC-7523  JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants
+ * https://tools.ietf.org/html/rfc7523#section-8
+ */
+public interface ClientAssertionParameterValues {
+
+	/**
+	 * {@code urn:ietf:params:oauth:client-assertion-type:jwt-bearer} - used in Access Token Request.
+	 */
+	String CLIENT_ASSERTION_TYPE_JWT_BEARER = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+	/**
+	 * {@code urn:ietf:params:oauth:grant-type:jwt-bearer} - used in Access Token Request.
+	 */
+	String CLIENT_GRANT_TYPE_JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+}


### PR DESCRIPTION
…ssue #8735

One of the protocols support by OAuth is Client Assertion as authentication

A client uses an assertion to authenticate to the authorization server's token endpoint by using the "client_assertion_type" and "client_assertion" parameters

https://tools.ietf.org/html/rfc7521#section-6.1

Current Behavior

No Support

Context

This is something supported by jose.nimbus and as consumer and provider of OAuth we want to secure our authentication to the token endpoint using this protocol.