### PR TITLE
Fixing Checkstyle issues.

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
@@ -126,7 +126,7 @@ abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T extend
 		if (ClientAuthenticationMethod.POST.equals(clientRegistration.getClientAuthenticationMethod())) {
 			body.with(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
 			body.with(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 			body.with(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverter.java
@@ -88,7 +88,7 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverter implements Conve
 		if (ClientAuthenticationMethod.POST.equals(clientRegistration.getClientAuthenticationMethod())) {
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 		}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationGrantRequestEntityUtils.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationGrantRequestEntityUtils.java
@@ -77,7 +77,7 @@ final class OAuth2AuthorizationGrantRequestEntityUtils {
 
 		JWT clientAssertion = null;
 
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())) {
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())) {
 
 			try {
 				ClientID clientID = new ClientID(clientRegistration.getClientId());
@@ -92,13 +92,13 @@ final class OAuth2AuthorizationGrantRequestEntityUtils {
 						, secret).getClientAssertion();
 			} catch (JOSEException e) {
 				OAuth2Error oauth2Error = new OAuth2Error("Client_secret_jwt",
-						"Encountered an error generating a client secret JWT",null);
-				throw new OAuth2AuthenticationException(oauth2Error,e.getMessage());
+						"Encountered an error generating a client secret JWT", null);
+				throw new OAuth2AuthenticationException(oauth2Error, e.getMessage());
 
 			} catch(URISyntaxException e){
 				OAuth2Error oauth2Error = new OAuth2Error("token_endpoint",
-						"The token endpoint provided or configured doesn't conform to a standard URI Pattern",null);
-				throw new OAuth2AuthenticationException(oauth2Error,e.getMessage());
+						"The token endpoint provided or configured doesn't conform to a standard URI Pattern", null);
+				throw new OAuth2AuthenticationException(oauth2Error, e.getMessage());
 			}
 		}
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2ClientCredentialsGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2ClientCredentialsGrantRequestEntityConverter.java
@@ -83,7 +83,7 @@ public class OAuth2ClientCredentialsGrantRequestEntityConverter implements Conve
 			formParameters.add(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 		}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2PasswordGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2PasswordGrantRequestEntityConverter.java
@@ -85,7 +85,7 @@ public class OAuth2PasswordGrantRequestEntityConverter implements Converter<OAut
 			formParameters.add(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 		}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2RefreshTokenGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2RefreshTokenGrantRequestEntityConverter.java
@@ -85,7 +85,7 @@ public class OAuth2RefreshTokenGrantRequestEntityConverter implements Converter<
 			formParameters.add(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 		}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
@@ -50,8 +50,8 @@ abstract class StdConverters {
 			if (ClientAuthenticationMethod.BASIC.getValue().equalsIgnoreCase(value)) {
 				return ClientAuthenticationMethod.BASIC;
 			} else if (ClientAuthenticationMethod.POST.getValue().equalsIgnoreCase(value)) {
-				return ClientAuthenticationMethod.POST;}
-			else if (ClientAuthenticationMethod.SECRET_JWT.getValue().equalsIgnoreCase(value)) {
+				return ClientAuthenticationMethod.POST;
+			} else if (ClientAuthenticationMethod.SECRET_JWT.getValue().equalsIgnoreCase(value)) {
 				return ClientAuthenticationMethod.SECRET_JWT;
 			} else if (ClientAuthenticationMethod.NONE.getValue().equalsIgnoreCase(value)) {
 				return ClientAuthenticationMethod.NONE;

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.security.oauth2.client.registration;
 
-import com.nimbusds.jose.JWSAlgorithm;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverterTests.java
@@ -34,7 +34,6 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
-import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.util.MultiValueMap;
 
 import java.util.Arrays;
@@ -44,7 +43,6 @@ import java.util.Map;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
 /**
@@ -199,7 +197,7 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverterTests {
 				.isEqualTo(ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 		assertThat(formParameters.getFirst(ClientAssertionParameterNames.CLIENT_ASSERTION))
 				.isNotEmpty();
-		assertTrue(validateJWTSecret(formParameters.getFirst(ClientAssertionParameterNames.CLIENT_ASSERTION),clientRegistration));
+		assertThat(validateJWTSecret(formParameters.getFirst(ClientAssertionParameterNames.CLIENT_ASSERTION), clientRegistration)).isTrue();
 
 	}
 
@@ -240,7 +238,7 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverterTests {
 		RequestEntity<?> requestEntity = this.converter.convert(authorizationCodeGrantRequest);
 	}
 
-	private boolean validateJWTSecret(String jwt,ClientRegistration registration ){
+	private boolean validateJWTSecret(String jwt, ClientRegistration registration ){
 
 		boolean success;
 

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterNames.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterNames.java
@@ -1,20 +1,17 @@
 /*
+ * Copyright 2002-2019 the original author or authors.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * Copyright 2020 Paychex, Inc.
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      https://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.security.oauth2.core.endpoint;

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterValues.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterValues.java
@@ -1,20 +1,17 @@
 /*
+ * Copyright 2002-2019 the original author or authors.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * Copyright 2020 Paychex, Inc.
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      https://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.security.oauth2.core.endpoint;


### PR DESCRIPTION
One of the protocols support by OAuth is Client Assertion as authentication

A client uses an assertion to authenticate to the authorization server's token endpoint by using the "client_assertion_type" and "client_assertion" parameters

https://tools.ietf.org/html/rfc7521#section-6.1

Current Behavior

No Support

Context

This is something supported by jose.nimbus and as consumer and provider of OAuth we want to secure our authentication to the token endpoint using this protocol.

#8735